### PR TITLE
Añadir .gitattributes a Tuki y usar el comando tr para solucionar el problema del CRLF

### DIFF
--- a/packager/.gitattributes
+++ b/packager/.gitattributes
@@ -1,0 +1,2 @@
+*.sh text eol=lf
+.env text eol=lf

--- a/packager/scripts/getDockerComposeFiles.sh
+++ b/packager/scripts/getDockerComposeFiles.sh
@@ -10,7 +10,7 @@ fi
 ENV_PATH="../dists/$MIYUKI_DIST/.env"
 
 if [ -f "$ENV_PATH" ]; then
-  export $(cat "$ENV_PATH" | xargs)
+  export $(cat "$ENV_PATH" | tr -d '\r' | xargs)
   echo "$MIYUKI_DIST will be packed"
 else
   echo ".env file not found for distribution '$MIYUKI_DIST' at $ENV_PATH"


### PR DESCRIPTION
Resolves #19 

Al ejecutar `npm run make` en Windows, obtenemos:
```
>> npm run make

> Miyuki@1.0.0 premake
> bash scripts/getDockerComposeFiles.sh

<3>WSL (5280 - Relay) ERROR: CreateProcessParseCommon:909: getpwuid(1000) failed 0
Getting docker-compose files...
scripts/getDockerComposeFiles.sh: line 2: $'\r': command not found
scripts/getDockerComposeFiles.sh: line 4: $'\r': command not found
scripts/getDockerComposeFiles.sh: line 35: syntax error near unexpected token `fi'
scripts/getDockerComposeFiles.sh: line 35: `fi'
```

Esto está causado por el carácter de fin de línea (\r) del formato CRLF, como es mencionado en este issue #19 

Para solucionarlo, propongo usar el archivo .gitattributes, el cual tiene un setting para configurar tanto extensiones de archivos como archivos específicos para que usen el formato LF (Line Feed, usado en Unix) en vez de CRLF (usado en DOS).

Las configuraciones serían las siguientes:
```
# ./packager/.gitattributes

*.sh text eol=lf
.env text eol=lf
```
Estas configuraciones afectan al getDockerComposeFiles.sh y .env dentro del directorio packager.

Para manejar los casos donde el .env está fuera de la carpeta packager (por ejemplo, dentro de dists/pdep), podemos usar el comando `tr -d '\r'` (translate) de la siguiente forma:
```sh
# ./packager/scripts/getDockerComposeFiles.sh
...
export $(cat "$ENV_PATH" | tr -d '\r' | xargs)
...
```
El comando tr en este caso elimina todos los \r del .env pasado mediante el cat.

### Testeado manualmente
Windows 11 64-bits ✅ Compila, ejecuta y pude resolver ejercicios.
Arch Linux 64-bits ✅Compila, ejecuta y pude resolver ejercicios.