### PR TITLE
Patch

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -29,6 +29,8 @@ COPY db/ /var/www/miyuki/db/
 ENV RAILS_LOG_TO_STDOUT=true
 ENV RAILS_SERVE_STATIC_FILES=true
 
+RUN cp -r $(bundle show mumuki-styles)/app/assets/fonts/* /var/www/miyuki/public/assets
+
 CMD ["rails", "s"]
 
 EXPOSE 3000


### PR DESCRIPTION
Related #2 

Las fonts están en el container en , pero no terminamos de encontrar la razón de por qué en entorno de producción no los precompila. 

La gema está instalada y las fonts están en esta ruta:

![imagen](https://github.com/user-attachments/assets/941af6d6-3372-41ec-8f7b-09f0eee61fef)

También vi que si consulto en la consola de rails por `Rails.application.config.assets.paths`, aparecen las rutas de mumuki-styles, entiendo que esto significa que las tiene disponibles para el precompile :thinking:, pero de ahí a cómo ver por qué no están en `public/assets` no se cómo hacer, no se si @facu777 logró encontrar algo más.

Probé un par de cosas pero no estoy segura si entiendo del todo como funciona el precompile de assets. Me parece que esto es algo que podemos intentar resolver nuevamente cuando nos juntemos. 

Mientras tanto tiro este parchecito para poder salir en esta semana en lo posible, armando la imagen del server con esta línea que copia las fonts de la gema a `public/assets`. **No es una solución final** pero sirve por ahora. 

Habría que volver a subir la imagen de `miyuki-server` a dockerhub @flbulgarelli si te parece.