### PR TITLE
Usar el comando de Docker Compose v2 en vez de docker-compose

### DIFF
--- a/packager/src/index.js
+++ b/packager/src/index.js
@@ -9,7 +9,7 @@ if (require('electron-squirrel-startup')) {
 }
 
 const miyukiDist = process.env.MIYUKI_DIST || "pdep";
-const command = `docker-compose -f ${process.resourcesPath}/docker/docker-compose.yml -f ${process.resourcesPath}/docker/docker-compose.${miyukiDist}.yml up -d`;
+const command = `docker compose -f ${process.resourcesPath}/docker/docker-compose.yml -f ${process.resourcesPath}/docker/docker-compose.${miyukiDist}.yml up -d`;
 
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {


### PR DESCRIPTION
Resolves #29 

Al instalar Docker, viene con Compose v2 ya integrado en el Docker CLI. El comando que estamos usando para levantar los containers:
```js
const command = `docker-compose -f ${process.resourcesPath}/docker/docker-compose.yml -f ${process.resourcesPath}/docker/docker-compose.${miyukiDist}.yml up -d`;
``` 
Está deprecado según la [branch oficial de Compose v1.](https://github.com/docker/compose/tree/v1)

> ⚠️ Compose V1 is DEPRECATED ⚠️
> Since [Compose V2 is now GA](https://www.docker.com/blog/announcing-compose-v2-general-availability/), Compose V1 is officially End of Life. This means that:
> 
> Active development and new features will only be added to the V2 codebase
> Only security-related issues will be considered for V1
> Check out the [V2 branch here](https://github.com/docker/compose/tree/v2/)!!

Testeado **manualmente** en:
- Arch Linux ✅ 
- VM con Ubuntu ✅ (acá me surgió el problema, ya que solo había instalado Docker y no docker-compose").
- Windows 11 ✅ 