### PR TITLE
Solución al error `miyuki-server` no inicia porque ya hay uno corriendo.

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,7 @@ services:
   miyuki-server:
     image: flbulgarelli/miyuki-server
     container_name: miyuki-server
+    command: /bin/sh -c "rm -f /var/www/miyuki/tmp/pids/server.pid && rails s"
     build:
       context: ..
       dockerfile: docker/server/Dockerfile


### PR DESCRIPTION
Resolves #34 

¡Buenas! El error que hacía que el container miyuki-server devolviera:
```
A server is already running. Check /var/www/miyuki/tmp/pids/server.pid. 
```
Era ocasionado porque Ruby no llegaba a borrar el server.pid al cerrarse abruptamente Docker (ya sea por apagado, reinicio, crasheo, etc). Para solucionarlo, agregué un campo `command` al docker-compose.yml para eliminar ese archivo que marcaba el log antes de iniciar el servidor de Rails. Por las pruebas que hice, no pude volver a replicar el error.

Tengo entendido que `command` sobreescribe el CMD del Dockerfile, por lo que capaz se podría sacar.

[Me guié principalmente de esta pregunta de StackOverflow.](https://stackoverflow.com/questions/35022428/rails-server-is-still-running-in-a-new-opened-docker-container)