### PR TITLE
Optimizaciones en el Dockerfile de miyuki-server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 ruby "3.2.2"
 
+
 gem 'mumukit-core', '~> 1.20'
 gem 'mumuki-domain', github: 'mumuki/mumuki-domain', branch: 'chore-update-ruby-version'
 gem 'mumukit-bridge', '~> 4.3'
@@ -11,7 +12,7 @@ gem 'muvment', '~> 1.4'
 
 
 gem 'font_awesome5_rails', '~> 1.3'
-
+gem 'concurrent-ruby', '1.3.4'
 gem 'faraday', '~> 2.3'
 gem 'faraday-retry', '~> 2.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cmath (1.0.0)
-    concurrent-ruby (1.3.4)
+    concurrent-ruby (1.2.2)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.2)
@@ -237,8 +237,6 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
-    nokogiri (1.14.3-x64-mingw-ucrt)
-      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     nprogress-rails (0.2.0.2)
@@ -355,7 +353,6 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.6.2-x64-mingw-ucrt)
     sqlite3 (1.6.2-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -368,8 +365,6 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2025.2)
-      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -392,13 +387,11 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
-  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
   bootsnap
   capybara
-  concurrent-ruby (= 1.3.4)
   debug
   faraday (~> 2.3)
   faraday-retry (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     cmath (1.0.0)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.4)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.2)
@@ -237,6 +237,8 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.5.9)
+    nokogiri (1.14.3-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     nprogress-rails (0.2.0.2)
@@ -353,6 +355,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.2-x64-mingw-ucrt)
     sqlite3 (1.6.2-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
@@ -365,6 +368,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.2)
+      tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
@@ -387,11 +392,13 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-linux
 
 DEPENDENCIES
   bootsnap
   capybara
+  concurrent-ruby (= 1.3.4)
   debug
   faraday (~> 2.3)
   faraday-retry (~> 2.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,5 +1,7 @@
 require_relative "boot"
+require "logger"
 require "rails/all"
+
 
 require 'mumukit/core'
 require 'sassc-rails'

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -15,11 +15,8 @@ RUN apk add --no-cache make gcc g++ musl-dev sqlite-dev tzdata git ruby-dev
 RUN bundle config build.sqlite3 --use-system-libraries \
     && bundle config set force_ruby_platform true \
     && bundle config set without development test \
-    && bundle install --jobs=8
-
-RUN bundle clean --force \
-    && apk del make gcc g++ musl-dev ruby-dev \
-    && rm -rf /var/cache/apk/*
+    && bundle install --jobs=8 \
+    && bundle clean --force 
 
 FROM ruby:3.2.2-alpine
 
@@ -57,5 +54,4 @@ RUN cp -r $(bundle show mumuki-styles)/app/assets/fonts/* /var/www/miyuki/public
 
 EXPOSE 3000
 
-CMD ["rails", "s"]
-
+CMD rm -f /var/www/miyuki/tmp/pids/server.pid && exec rails s

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -57,5 +57,5 @@ RUN cp -r $(bundle show mumuki-styles)/app/assets/fonts/* /var/www/miyuki/public
 
 EXPOSE 3000
 
-CMD ["rails", "s", "-e", "production"]
+CMD ["rails", "s"]
 

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2.2-bullseye
+FROM ruby:3.2.2-alpine AS builder
 
 ENV RAILS_ENV=production
 ENV RACK_ENV=production
@@ -9,7 +9,31 @@ RUN mkdir -p /var/www/miyuki
 WORKDIR /var/www/miyuki
 
 COPY Gemfile* /var/www/miyuki/
-RUN bundle install --without development test
+
+RUN apk add --no-cache make gcc g++ musl-dev sqlite-dev tzdata git ruby-dev
+
+RUN bundle config build.sqlite3 --use-system-libraries \
+    && bundle config set force_ruby_platform true \
+    && bundle config set without development test \
+    && bundle install --jobs=8
+
+RUN bundle clean --force \
+    && apk del make gcc g++ musl-dev ruby-dev \
+    && rm -rf /var/cache/apk/*
+
+FROM ruby:3.2.2-alpine
+
+ENV RAILS_ENV=production
+ENV RACK_ENV=production
+
+WORKDIR /var/www/miyuki
+
+COPY --from=builder /var/www/miyuki .
+COPY --from=builder /usr/local/bundle /usr/local/bundle
+
+RUN apk add --no-cache \
+    sqlite \
+    tzdata
 
 COPY app/ /var/www/miyuki/app/
 COPY config/ /var/www/miyuki/config/
@@ -31,6 +55,7 @@ ENV RAILS_SERVE_STATIC_FILES=true
 
 RUN cp -r $(bundle show mumuki-styles)/app/assets/fonts/* /var/www/miyuki/public/assets
 
-CMD ["rails", "s"]
-
 EXPOSE 3000
+
+CMD ["rails", "s", "-e", "production"]
+


### PR DESCRIPTION
¡Hola! 
Estuve experimentando un poco con el Dockerfile y la variante `ruby:3.2.2-alpine` en lugar de `ruby:3.2.2-bullseye` y logré bajar bastante el tamaño de la imagen final. 
Antes:
![image](https://github.com/user-attachments/assets/80f7428c-d29f-4049-a0f9-90fcb45ababd)
Después:
![image](https://github.com/user-attachments/assets/f7df4f28-f4af-412a-b976-7d3bd525c975)

Tuve que hacer algunos agregados en el Gemfile y el applications.rb.
Me dirán si está bien porque sé muy poco de Ruby y Rails. Estos añadidos son porque el container fallaba al iniciar y esa fue la solución que encontré para hacerlo andar.

Para probarlo, puede bajarse la rama main de mi fork y en la carpeta miyuki/docker ejecutan.
```bash
docker compose build miyuki-server
```
Esto hace el build únicamente de la imagen de miyuki-server en base al Dockerfile optimizado y luego pueden abrir la aplicación para que levante esa imagen en vez de pullear la que está subida. Esto lo digo más que nada así no lo suben a Docker Hub nomás para probarlo. 😁

