### PR TITLE
Agregar markdown a pistas + sacar recuadro azul

### DIFF
--- a/src/frontend/Exercise.tsx
+++ b/src/frontend/Exercise.tsx
@@ -13,6 +13,7 @@ import { Exercise as ExerciseModel } from "./model/guide";
 import { ProgressBar } from "./ProgressBar";
 import { ContentTitle } from "./Title";
 import Feedback from "./Feedback";
+import { LightbulbIcon } from "./icons/Icons";
 
 type FeedbackData = Record<string, string>
 const populate = (template: string, data: FeedbackData) => template.replace(/\${(\w+)}/g, (_, key) => data[key]);
@@ -95,19 +96,28 @@ const Assignment: React.FC<{
       {exercise.hint && (
         <button
           onClick={() => setShowHint(!showHint)}
-          className="text-blue-600 flex items-center gap-2 mb-2">
-          💡 {t("needAHint")}
+          className="text-mumuki-skyblue flex items-center gap-2 mb-2 hover:underline">
+          <LightbulbIcon width={16} height={16} />
+          {t("needAHint")}
         </button>
       )}
 
-      {showHint && (
-        <div className="bg-blue-50 border border-blue-200 p-3 rounded">
-          {exercise.hint}
-        </div>
-      )}
+      {showHint && <HintBox hint={exercise.hint} />}
     </div>
   );
 };
+
+
+type HintBoxProps = {
+  hint: string;
+};
+const HintBox = ({ hint }: HintBoxProps) => (
+  <div className="mb-5">
+    <Description className="p-3">
+      {hint}
+    </Description>
+  </div>
+);
 
 const layout = {
   text: {

--- a/src/frontend/Exercise.tsx
+++ b/src/frontend/Exercise.tsx
@@ -111,6 +111,7 @@ const Assignment: React.FC<{
 type HintBoxProps = {
   hint: string;
 };
+
 const HintBox = ({ hint }: HintBoxProps) => (
   <div className="mb-5">
     <Description className="p-3">

--- a/src/frontend/Feedback.tsx
+++ b/src/frontend/Feedback.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { AnalysisResult, InspectionRule, TestReport } from "yukigo";
+import { CheckIcon, CrossIcon, ErrorIcon, SuccessIcon, WarningIcon } from "./icons/Icons";
 
 type Props = {
   results: TestReport[] | null;
@@ -11,10 +12,6 @@ const testsOk = (tests: TestReport[]) =>
   tests.every((res) => res.status === "passed");
 const expectationsOk = (expectations: AnalysisResult[]) =>
   expectations.every((res) => res.passed);
-
-type IconProps = {
-  className?: string;
-};
 
 const colorStyles = {
   red: {
@@ -30,62 +27,6 @@ const colorStyles = {
     text: "text-green-700",
   },
 };
-
-const ErrorIcon = ({ className }: IconProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    fill="currentColor"
-    className={className}
-    viewBox="0 0 16 16">
-    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M4.5 7.5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1z" />
-  </svg>
-);
-const WarningIcon = ({ className }: IconProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    fill="currentColor"
-    className={className}
-    viewBox="0 0 16 16">
-    <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2" />
-  </svg>
-);
-const SuccessIcon = ({ className }: IconProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    fill="currentColor"
-    className={className}
-    viewBox="0 0 16 16">
-    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z" />
-  </svg>
-);
-const CrossIcon = ({ className }: IconProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    fill="currentColor"
-    className={className}
-    viewBox="0 0 16 16">
-    <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708" />
-  </svg>
-);
-const CheckIcon = ({ className }: IconProps) => (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    width="20"
-    height="20"
-    fill="currentColor"
-    className={className}
-    viewBox="0 0 16 16">
-    <path d="M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425z" />
-  </svg>
-);
 
 type FeedbackColor = "red" | "yellow" | "green";
 
@@ -122,7 +63,7 @@ const FeedbackMessage = ({ msg }: MessageProps) => (
 const TestReportRow = ({ name, status, message }: TestReport) => (
   <div className="bg-white p-2 flex flex-col">
     <div className="flex gap-2 items-center">
-      {status === "passed" ? <CheckIcon /> : <CrossIcon />}
+      {status === "passed" ? <CheckIcon width={20} height={20} /> : <CrossIcon width={20} height={20} />}
       <p>{name}</p>
     </div>
     {message && <p className="ml-8 text-sm text-gray-600">{message}</p>}
@@ -147,7 +88,7 @@ const ErrorFeedback = (error: Error) => {
     <FeedbackTitle
       heading={t("errored")}
       color={"red"}
-      icon={<ErrorIcon className="fill-red-700" />}
+      icon={<ErrorIcon width={20} height={20} className="fill-red-700" />}
     />
     <FeedbackMessage msg={error.message} />
   </FeedbackContainer>;
@@ -160,7 +101,7 @@ const TestsFeedback = (results: TestReport[]) => {
       <FeedbackTitle
         heading={t("failed")}
         color={"red"}
-        icon={<ErrorIcon className="fill-red-700" />}
+        icon={<ErrorIcon width={20} height={20} className="fill-red-700" />}
       />
       {results.map((report, i) => (
         <TestReportItem key={i} {...report} />
@@ -184,7 +125,7 @@ const ExpectationResult = (
 
   return (
     <span className="flex gap-2" key={index}>
-      {passed ? <CheckIcon /> : <CrossIcon />}
+      {passed ? <CheckIcon width={20} height={20} /> : <CrossIcon width={20} height={20} />}
       <p>
         {t(`yukigo:${translationKey}`, {
           binding: binding === "*" ? t("yukigo:solution") : binding,
@@ -206,7 +147,7 @@ const ExpectationsFeedback = (expectations: AnalysisResult[]) => {
       <FeedbackTitle
         heading={t("failedExpectations")}
         color={"yellow"}
-        icon={<WarningIcon className="fill-yellow-700" />}
+        icon={<WarningIcon width={20} height={20} className="fill-yellow-700" />}
       />
       <div className="bg-white border rounded p-3 text-sm font-mono">
         {expectations.map(({ rule, passed }, index) =>
@@ -224,7 +165,7 @@ const SuccessFeedback = () => {
     <FeedbackTitle
       heading={t("passed")}
       color={"green"}
-      icon={<SuccessIcon className="fill-green-700" />}
+      icon={<SuccessIcon width={20} height={20} className="fill-green-700" />}
     />
   </FeedbackContainer>;
 };

--- a/src/frontend/icons/Icons.tsx
+++ b/src/frontend/icons/Icons.tsx
@@ -1,0 +1,73 @@
+type IconProps = {
+  className?: string;
+  width: string | number;
+  height: string | number;
+};
+
+export const LightbulbIcon = ({ className, width, height }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="currentColor"
+    className={className}
+    viewBox="0 0 16 16">
+    <path d="M2 6a6 6 0 1 1 10.174 4.31c-.203.196-.359.4-.453.619l-.762 1.769A.5.5 0 0 1 10.5 13a.5.5 0 0 1 0 1 .5.5 0 0 1 0 1l-.224.447a1 1 0 0 1-.894.553H6.618a1 1 0 0 1-.894-.553L5.5 15a.5.5 0 0 1 0-1 .5.5 0 0 1 0-1 .5.5 0 0 1-.46-.302l-.761-1.77a2 2 0 0 0-.453-.618A5.98 5.98 0 0 1 2 6m6-5a5 5 0 0 0-3.479 8.592c.263.254.514.564.676.941L5.83 12h4.342l.632-1.467c.162-.377.413-.687.676-.941A5 5 0 0 0 8 1" />
+  </svg>
+);
+
+export const ErrorIcon = ({ className, width, height }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="currentColor"
+    className={className}
+    viewBox="0 0 16 16">
+    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M4.5 7.5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1z" />
+  </svg>
+);
+export const WarningIcon = ({ className, width, height }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="currentColor"
+    className={className}
+    viewBox="0 0 16 16">
+    <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2" />
+  </svg>
+);
+export const SuccessIcon = ({ className, width, height }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="currentColor"
+    className={className}
+    viewBox="0 0 16 16">
+    <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z" />
+  </svg>
+);
+export const CrossIcon = ({ className, width, height }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="currentColor"
+    className={className}
+    viewBox="0 0 16 16">
+    <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708" />
+  </svg>
+);
+export const CheckIcon = ({ className, width, height }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={width}
+    height={height}
+    fill="currentColor"
+    className={className}
+    viewBox="0 0 16 16">
+    <path d="M12.736 3.97a.733.733 0 0 1 1.047 0c.286.289.29.756.01 1.05L7.88 12.01a.733.733 0 0 1-1.065.02L3.217 8.384a.757.757 0 0 1 0-1.06.733.733 0 0 1 1.047 0l3.052 3.093 5.4-6.425z" />
+  </svg>
+);

--- a/src/frontend/icons/Icons.tsx
+++ b/src/frontend/icons/Icons.tsx
@@ -27,6 +27,7 @@ export const ErrorIcon = ({ className, width, height }: IconProps) => (
     <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0M4.5 7.5a.5.5 0 0 0 0 1h7a.5.5 0 0 0 0-1z" />
   </svg>
 );
+
 export const WarningIcon = ({ className, width, height }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -38,6 +39,7 @@ export const WarningIcon = ({ className, width, height }: IconProps) => (
     <path d="M8.982 1.566a1.13 1.13 0 0 0-1.96 0L.165 13.233c-.457.778.091 1.767.98 1.767h13.713c.889 0 1.438-.99.98-1.767zM8 5c.535 0 .954.462.9.995l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 5.995A.905.905 0 0 1 8 5m.002 6a1 1 0 1 1 0 2 1 1 0 0 1 0-2" />
   </svg>
 );
+
 export const SuccessIcon = ({ className, width, height }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -49,6 +51,7 @@ export const SuccessIcon = ({ className, width, height }: IconProps) => (
     <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0m-3.97-3.03a.75.75 0 0 0-1.08.022L7.477 9.417 5.384 7.323a.75.75 0 0 0-1.06 1.06L6.97 11.03a.75.75 0 0 0 1.079-.02l3.992-4.99a.75.75 0 0 0-.01-1.05z" />
   </svg>
 );
+
 export const CrossIcon = ({ className, width, height }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
@@ -60,6 +63,7 @@ export const CrossIcon = ({ className, width, height }: IconProps) => (
     <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708" />
   </svg>
 );
+
 export const CheckIcon = ({ className, width, height }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ module.exports = {
   theme: {
     extend: {
       colors: {
+        "mumuki-skyblue": "#3498DB",
         "mumuki-rose": "#ff5b81",
         "mumuki-rose-darken": "#d94d6e"
       }


### PR DESCRIPTION
Closes #99 

- Agregue el celeste de Mumuki a la config de Tailwind
- Saque el recuadro azul a la caja de la pista
- Cambie el icono a uno que se parece mas al de Font Awesome. [Es este, de bootstrap](https://icons.getbootstrap.com/icons/lightbulb/) 
- Le agregue markdown al texto reusando el componente `Description`. Quizas habria que ponerle un nombre mas _descriptivo_ (ja!).

Tambien aproveche y saque todos los iconos que estaban en `Feedback.tsx` a su propio archivo, para tener todo mas ordenado.