### PR TITLE
Permitir copiar en el editor

### DIFF
--- a/src/frontend/Exercise.tsx
+++ b/src/frontend/Exercise.tsx
@@ -150,7 +150,18 @@ const Exercise: React.FC = () => {
 
   const editorRef = useRef<any>(null);
 
-  const handleEditorMount: OnMount = (editor) => {
+  const handleEditorMount: OnMount = (editor, monaco) => {
+    editor.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyV,
+      async () => {
+        try {
+          const text = await navigator.clipboard.readText();
+          editor.trigger("keyboard", "type", { text });
+        } catch (err) {
+          console.warn("Fallo lectura del clipboard:", err);
+        }
+      }
+    );
     editorRef.current = editor;
   };
 

--- a/src/frontend/Feedback.tsx
+++ b/src/frontend/Feedback.tsx
@@ -140,20 +140,28 @@ const TestReportItem = (report: TestReport) =>
     <TestReportRow {...report} />
   );
 
-const ErrorFeedback = (error: Error) => {
+type ErrorFeedbackProps = {
+  error: Error;
+};
+const ErrorFeedback = ({ error }: ErrorFeedbackProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
 
-  <FeedbackContainer color={"red"}>
-    <FeedbackTitle
-      heading={t("errored")}
-      color={"red"}
-      icon={<ErrorIcon className="fill-red-700" />}
-    />
-    <FeedbackMessage msg={error.message} />
-  </FeedbackContainer>;
+  return (
+    <FeedbackContainer color={"red"}>
+      <FeedbackTitle
+        heading={t("errored")}
+        color={"red"}
+        icon={<ErrorIcon className="fill-red-700" />}
+      />
+      <FeedbackMessage msg={error.message} />
+    </FeedbackContainer>
+  );
 };
 
-const TestsFeedback = (results: TestReport[]) => {
+type TestsFeedbackProps = {
+  results: TestReport[];
+};
+const TestsFeedback = ({ results }: TestsFeedbackProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
   return (
     <FeedbackContainer color={"red"}>
@@ -169,11 +177,12 @@ const TestsFeedback = (results: TestReport[]) => {
   );
 };
 
-const ExpectationResult = (
-  rule: InspectionRule,
-  index: number,
-  passed: boolean,
-) => {
+type ExpectationResultProps = {
+  rule: InspectionRule;
+  index: number;
+  passed: boolean;
+};
+const ExpectationResult = ({ rule, index, passed }: ExpectationResultProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
 
   const { inspection, args, binding, expected, targetSuffix, matcher } = rule;
@@ -199,7 +208,10 @@ const ExpectationResult = (
   );
 };
 
-const ExpectationsFeedback = (expectations: AnalysisResult[]) => {
+type ExpectationsFeedbackProps = {
+  expectations: AnalysisResult[];
+};
+const ExpectationsFeedback = ({ expectations }: ExpectationsFeedbackProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
   return (
     <FeedbackContainer color={"yellow"}>
@@ -209,9 +221,9 @@ const ExpectationsFeedback = (expectations: AnalysisResult[]) => {
         icon={<WarningIcon className="fill-yellow-700" />}
       />
       <div className="bg-white border rounded p-3 text-sm font-mono">
-        {expectations.map(({ rule, passed }, index) =>
-          ExpectationResult(rule, index, passed),
-        )}
+        {expectations.map(({ rule, passed }, index) => (
+          <ExpectationResult rule={rule} index={index} passed={passed} />
+        ))}
       </div>
     </FeedbackContainer>
   );
@@ -220,24 +232,26 @@ const ExpectationsFeedback = (expectations: AnalysisResult[]) => {
 const SuccessFeedback = () => {
   const { t } = useTranslation(["translation", "yukigo"]);
 
-  <FeedbackContainer color={"green"}>
-    <FeedbackTitle
-      heading={t("passed")}
-      color={"green"}
-      icon={<SuccessIcon className="fill-green-700" />}
-    />
-  </FeedbackContainer>;
+  return (
+    <FeedbackContainer color={"green"}>
+      <FeedbackTitle
+        heading={t("passed")}
+        color={"green"}
+        icon={<SuccessIcon className="fill-green-700" />}
+      />
+    </FeedbackContainer>
+  );
 };
 
 export default function Feedback({ results, expectations, error }: Props) {
   if (!results && !expectations && !error) return <></>;
 
-  if (error) return ErrorFeedback(error);
+  if (error) return <ErrorFeedback error={error} />;
 
-  if (results && !testsOk(results)) TestsFeedback(results);
+  if (results && !testsOk(results)) return <TestsFeedback results={results} />;
 
   if (expectations && !expectationsOk(expectations))
-    return ExpectationsFeedback(expectations);
+    return <ExpectationsFeedback expectations={expectations} />;
 
-  return SuccessFeedback();
+  return <SuccessFeedback />;
 }

--- a/src/frontend/Feedback.tsx
+++ b/src/frontend/Feedback.tsx
@@ -143,6 +143,7 @@ const TestReportItem = (report: TestReport) =>
 type ErrorFeedbackProps = {
   error: Error;
 };
+
 const ErrorFeedback = ({ error }: ErrorFeedbackProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
 
@@ -161,6 +162,7 @@ const ErrorFeedback = ({ error }: ErrorFeedbackProps) => {
 type TestsFeedbackProps = {
   results: TestReport[];
 };
+
 const TestsFeedback = ({ results }: TestsFeedbackProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
   return (
@@ -182,6 +184,7 @@ type ExpectationResultProps = {
   index: number;
   passed: boolean;
 };
+
 const ExpectationResult = ({ rule, index, passed }: ExpectationResultProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
 
@@ -211,6 +214,7 @@ const ExpectationResult = ({ rule, index, passed }: ExpectationResultProps) => {
 type ExpectationsFeedbackProps = {
   expectations: AnalysisResult[];
 };
+
 const ExpectationsFeedback = ({ expectations }: ExpectationsFeedbackProps) => {
   const { t } = useTranslation(["translation", "yukigo"]);
   return (


### PR DESCRIPTION
Closes #96 

- Arregle unos problemas del componente Feedback. En general me habia comido unos `return` y ademas estaba usando los componentes como funciones cosa que a React no le gusta
- Arregle el pegar en el Editor registrandole un comando que cuando detecta el CTRL+V lo escriba en el editor. Era un error interno de monaco-editor que pasaba por `productService` (whatever that is) y rompia, de esta forma no pasamos por ahi.